### PR TITLE
Allow downloading EDID binaries

### DIFF
--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -15,6 +15,8 @@ urlpatterns = patterns(
     # EDID
     url(r'^edid/(?P<pk>\d+)/$', views.EDIDDetailView.as_view(),
         name='edid-detail'),
+    url(r'^edid/(?P<pk>\d+)/download/$', views.EDIDDownloadView.as_view(),
+        name='edid-download'),
     url(r'^edid/(?P<pk>\d+)/update/$', views.EDIDUpdate.as_view(),
         name='edid-update'),
     url(r'^edid/upload/binary/$', views.EDIDBinaryUpload.as_view(),

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseRedirect, Http404)
 from django.shortcuts import get_object_or_404
+from django.utils.encoding import smart_str
 from django.views.generic import DetailView, ListView, TemplateView, View
 from django.views.generic.edit import (FormView, CreateView, UpdateView,
                                        DeleteView)
@@ -218,6 +219,23 @@ class EDIDDetailView(PrefetchRelatedMixin, DetailView):
         context['comment_form'] = CommentForm(initial={'edid': self.object})
 
         return context
+
+
+class EDIDDownloadView(DetailView):
+    model = EDID
+
+    def get(self, request, *args, **kwargs):
+        obj = self.get_object()
+        response = HttpResponse(mimetype='application/octet-stream')
+        response.content = base64.b64decode(obj.file_base64)
+
+        if obj.monitor_name:
+            name = "%s_%s" % (smart_str(obj.monitor_name), smart_str(obj.manufacturer_serial_number))
+        else:
+            name = smart_str(obj.manufacturer_serial_number)
+
+        response['Content-Disposition'] = 'attachment; filename=%s.edid' % name
+        return response
 
 
 class EDIDUpdate(LoginRequiredMixin, PrefetchRelatedMixin, UpdateView):

--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -41,6 +41,7 @@
       <a class="btn disabled" href="#" data-toggle="tooltip" title="Registration is required to make changes."><i class="icon-edit"></i> Update</a>
     {% endif %}
       <a class="btn" href="{% url 'edid-revision-list' edid.pk %}">Revisions</a>
+      <a class="btn btn-primary" href="{% url 'edid-download' edid.pk %}">Download binary</a>
     </p>
   {% endif %}
 


### PR DESCRIPTION
This PR adds a download button to the EDID detail view and allows downloading the binaries.

Fixes: https://github.com/timvideos/edid.tv/issues/11