### PR TITLE
Implement parsing of CVT Support Definition

### DIFF
--- a/edid_parser/edid_parser.py
+++ b/edid_parser/edid_parser.py
@@ -37,6 +37,14 @@ class TimingSyncScheme(object):
     Digital_Separate = 0b11
 
 
+class CVTSupportDefinitionPreferredAspectRatio(object):
+    AR_4_3 = 0b000
+    AR_16_9 = 0b001
+    AR_16_10 = 0b010
+    AR_5_4 = 0b011
+    AR_15_9 = 0b100
+
+
 class EDIDParser(object):
     def __init__(self, bin_data=None):
         """
@@ -492,6 +500,9 @@ class EDIDParser(object):
 
         new_data['Max_Supported_Pixel_Clock'] = edid[4] * 10
 
+        new_data['Coordinated_Video_Timings_supported'] = False
+        new_data['Secondary_GTF_curve_supported'] = False
+
         if edid[5] == 0x02:
             new_data['Secondary_GTF_curve_supported'] = True
             gtf = {}
@@ -503,8 +514,34 @@ class EDIDParser(object):
             gtf['J'] = float(edid[12]) / 2
 
             new_data['Secondary_GTF'] = gtf
-        else:
-            new_data['Secondary_GTF_curve_supported'] = False
+        elif edid[5] == 0x04:
+            new_data['Coordinated_Video_Timings_supported'] = True
+            new_data['Max_Supported_Pixel_Clock'] -= (edid[7] >> 2) * 0.25
+            new_data['Max_Active_Pixels_per_Line'] = (((edid[7] & 0b11) << 8) + edid[8]) * 8
+            new_data['Aspect_Ratio_4:3_supported'] = \
+                (edid[9] & 0b10000000) != 0
+            new_data['Aspect_Ratio_16:9_supported'] = \
+                (edid[9] & 0b01000000) != 0
+            new_data['Aspect_Ratio_16:10_supported'] = \
+                (edid[9] & 0b00100000) != 0
+            new_data['Aspect_Ratio_5:4_supported'] = \
+                (edid[9] & 0b00010000) != 0
+            new_data['Aspect_Ratio_15:9_supported'] = \
+                (edid[9] & 0b00001000) != 0
+            new_data['Preferred_Aspect_Ratio'] = edid[10] >> 5
+            new_data['CVT_Standard_Blanking_supported'] = \
+                (edid[10] & 0b01000) != 0
+            new_data['CVT_Reduced_Blanking_supported'] = \
+                (edid[10] & 0b10000) != 0
+            new_data['Horizontal_Shrink_supported'] = \
+                (edid[11] & 0b10000000) != 0
+            new_data['Horizontal_Stretch_supported'] = \
+                (edid[11] & 0b01000000) != 0
+            new_data['Vertical_Shrink_supported'] = \
+                (edid[11] & 0b00100000) != 0
+            new_data['Vertical_Stretch_supported'] = \
+                (edid[11] & 0b00010000) != 0
+            new_data['Preferred_Vertical_Refresh_Rate'] = edid[12]
 
         return new_data
 

--- a/edid_parser/tests.py
+++ b/edid_parser/tests.py
@@ -4,7 +4,7 @@
 
 import unittest
 from edid_parser import (EDIDParser, EDIDParsingError, DisplayType,
-                         DisplayStereoMode, TimingSyncScheme)
+                         DisplayStereoMode, TimingSyncScheme, CVTSupportDefinitionPreferredAspectRatio)
 
 
 class EDIDTest(unittest.TestCase):
@@ -458,6 +458,39 @@ class EDIDValidTest(EDIDTest):
         self.assertEqual(data['Secondary_GTF']['M'], 32971)
         self.assertEqual(data['Secondary_GTF']['K'], 188)
         self.assertEqual(data['Secondary_GTF']['J'], 86.5)
+
+        test_edid = [0x30, 0x55, 0x1E, 0x5D, 0x11, 0x04, 0x11, 0x50, 0xD2,
+                     0xF8, 0x58, 0xF0, 0x00]
+        data = self.parser.parse_monitor_descriptor_range_limits(test_edid)
+
+        self.assertEqual(data['Min_Vertical_rate'], 48)
+        self.assertEqual(data['Max_Vertical_rate'], 85)
+
+        self.assertEqual(data['Min_Horizontal_rate'], 30)
+        self.assertEqual(data['Max_Horizontal_rate'], 93)
+
+        self.assertEqual(data['Max_Supported_Pixel_Clock'], 165)
+
+        self.assertEqual(data['Coordinated_Video_Timings_supported'], True)
+
+        self.assertEqual(data['Max_Active_Pixels_per_Line'], 1680)
+
+        self.assertEqual(data['Aspect_Ratio_4:3_supported'], True)
+        self.assertEqual(data['Aspect_Ratio_16:9_supported'], True)
+        self.assertEqual(data['Aspect_Ratio_16:10_supported'], True)
+        self.assertEqual(data['Aspect_Ratio_5:4_supported'], True)
+        self.assertEqual(data['Aspect_Ratio_15:9_supported'], True)
+        self.assertEqual(data['Preferred_Aspect_Ratio'], CVTSupportDefinitionPreferredAspectRatio.AR_16_10)
+
+        self.assertEqual(data['CVT_Standard_Blanking_supported'], True)
+        self.assertEqual(data['CVT_Reduced_Blanking_supported'], True)
+
+        self.assertEqual(data['Horizontal_Shrink_supported'], True)
+        self.assertEqual(data['Horizontal_Stretch_supported'], True)
+        self.assertEqual(data['Vertical_Shrink_supported'], True)
+        self.assertEqual(data['Vertical_Stretch_supported'], True)
+
+        self.assertEqual(data['Preferred_Vertical_Refresh_Rate'], 0)
 
 
 class EDIDInvalidTest(EDIDTest):

--- a/frontend/static/css/edid.css
+++ b/frontend/static/css/edid.css
@@ -16,6 +16,24 @@ body {
     width: 100%;
 }
 
+/* Nested tables
+------------------------- */
+td.nested-table {
+  padding: 0;
+}
+
+td.nested-table > .table {
+  margin: 0;
+}
+
+td.nested-table > .table > thead > tr > th:first-child {
+  border-left: 0;
+}
+
+td.nested-table > .table > tbody > tr > td:first-child {
+  border-left: 0;
+}
+
 /* Comments
 ------------------------- */
 

--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -284,6 +284,95 @@
             <td>{{ edid.mrl_secondary_gtf_j }}</td>
           </tr>
     {% endif %}
+          <tr>
+            <td>Coordinated Video Timings supported</td>
+            <td><i class="icon-{{ edid.mrl_coordinated_video_timing_support|yesno:"ok,remove" }}"></i></td>
+          </tr>
+    {% if edid.mrl_coordinated_video_timing_support %}
+          <tr>
+            <td>Maximum active pixels per line</td>
+            <td>{{ edid.mrl_cvt_max_active_pixels_per_line }}</td>
+          </tr>
+          <tr>
+            <td>Preferred aspect ratio</td>
+            <td>{{ edid.get_mrl_cvt_preferred_aspect_ratio_display }}</td>
+          </tr>
+          <tr>
+            <td>Preferred vertical refresh rate</td>
+            <td>{{ edid.mrl_cvt_preferred_vertical_refresh_rate }} Hz</td>
+          </tr>
+          <tr>
+            <td>Supported aspect ratios</td>
+            <td class="nested-table">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>4:3</th>
+                    <th>16:9</th>
+                    <th>16:10</th>
+                    <th>5:4</th>
+                    <th>15:9</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><i class="icon-{{ edid.mrl_cvt_aspect_ratio_4_3_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_aspect_ratio_16_9_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_aspect_ratio_16_10_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_aspect_ratio_5_4_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_aspect_ratio_15_9_supported|yesno:"ok,remove" }}"></i></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td>Supported blanking modes</td>
+            <td class="nested-table">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Standard</th>
+                    <th>Reduced</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><i class="icon-{{ edid.mrl_cvt_standard_blanking_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_reduced_blanking_supported|yesno:"ok,remove" }}"></i></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td>Supported scaling modes</td>
+            <td class="nested-table">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th colspan="2">Horizontal</th>
+                    <th colspan="2">Vertical</th>
+                  </tr>
+                  <tr>
+                    <th>Shrink</th>
+                    <th>Stretch</th>
+                    <th>Shrink</th>
+                    <th>Stretch</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><i class="icon-{{ edid.mrl_cvt_horizontal_shrink_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_horizontal_stretch_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_vertical_shrink_supported|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.mrl_cvt_vertical_stretch_supported|yesno:"ok,remove" }}"></i></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+    {% endif %}
         </tbody>
       </table>
     </section>


### PR DESCRIPTION
This PR adds support for parsing the optional CVT Support Definition included in some Display Range Limits Display Descriptors.

I've also added some CSS for nested tables as I felt that this was a nice and compact way to present the indicated support values:
![screenshot from 2018-12-10 20-23-15](https://user-images.githubusercontent.com/1225211/49755945-b0ca5700-fcb9-11e8-8987-ee89dbd7ffac.png)
(yes, this EDID indeed does indicate a preferred vertical refresh rate of 0 Hz)

Note that this commit not only adds new properties to the EDID model, but also changes the type of `mrl_max_pixel_clock` to allow for the 0.25 MHz precision introduced by the CVT Support Definition.