### PR TITLE
Show meaningful value for "Display Type"

### DIFF
--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -105,7 +105,7 @@
       {% endif %}
           <tr>
             <td>Display Type</td>
-            <td>{{ edid.bdp_feature_display_type }}</td>
+            <td>{{ edid.get_bdp_feature_display_type_display }}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Currently we just show an enum value, which is quite useless.