### PR TITLE
Correctly calculate the refresh rate of detailed timings

### DIFF
--- a/frontend/django_tests/test_models.py
+++ b/frontend/django_tests/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from edid_parser.edid_parser import EDIDParser
 
 from frontend.django_tests.base import EDIDTestMixin
-from frontend.models import EDID, Manufacturer, StandardTiming, Comment
+from frontend.models import EDID, Manufacturer, StandardTiming, Comment, DetailedTiming
 
 
 ### EDID Tests
@@ -414,6 +414,13 @@ class StandardTimingTestCase(TimingTestMixin, EDIDTestMixin, TestCase):
 class DetailedTimingTestCase(TimingTestMixin, EDIDTestMixin, TestCase):
     def _get_timings_set(self):
         return self.edid.detailedtiming_set
+
+    def test_get_refresh_rate(self):
+        detailed_timing = DetailedTiming(horizontal_active=1920, horizontal_blanking=280,
+                                         vertical_active=1080, vertical_blanking=45,
+                                         pixel_clock=148500)
+
+        self.assertEqual(detailed_timing.get_refresh_rate(), 60.00)
 
 
 ### Comment Tests

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -5,6 +5,7 @@
 # R0915: Too many statements
 # W0201: Attribute 'xxxx' defined outside __init__
 # pylint: disable-msg=E1002,R0201,R0902,R0912,R0915,W0201
+from __future__ import division
 
 import re
 
@@ -595,7 +596,7 @@ class EDID(models.Model):
                 maximum_resolution,
                 timing.horizontal_active,
                 timing.vertical_active,
-                timing.pixel_clock / 1000
+                timing.get_refresh_rate()
             )
 
         return maximum_resolution
@@ -747,9 +748,14 @@ class DetailedTiming(Timing):
     # not flags_sync_scheme == Digital_Separate
     flags_sync_on_rgb = models.NullBooleanField('sync on RGB')
 
+    def get_refresh_rate(self):
+        return round((self.pixel_clock * 1000) /
+                     ((self.horizontal_active + self.horizontal_blanking)
+                      * (self.vertical_active + self.vertical_blanking)), 2)
+
     def __unicode__(self):
-        return "%dx%d@%dHz" % (self.horizontal_active, self.vertical_active,
-                               self.pixel_clock / 1000)
+        return "%dx%d@%fHz" % (self.horizontal_active, self.vertical_active,
+                               self.get_refresh_rate())
 
 
 # Default settings for Comment model

--- a/templates/frontend/detailedtiming_table.html
+++ b/templates/frontend/detailedtiming_table.html
@@ -5,6 +5,10 @@
       <td>{{ timing.pixel_clock }} kHz</td>
     </tr>
     <tr>
+      <td>Refresh rate</td>
+      <td>{{ timing.get_refresh_rate|floatformat:2 }} Hz</td>
+    </tr>
+    <tr>
       <td>Horizontal Active</td>
       <td>{{ timing.horizontal_active }} pixels</td>
     </tr>


### PR DESCRIPTION
From the first commit message:

>Currently, we calculate the refresh rate of a detailed timing by
>dividing its pixel clock by 1000. This doesn't make any sense.
>
>To get the refresh rate we must calculate the total number of pixels
>in one complete frame (active + blanking) and divide the pixel clock by
>that value. Thus, this is the correct formula:
>
>RefreshRate = PixelClock / ((HActive + HBlank) * (VActive + VBlank))
>
>As the pixel clock has steps of 10 kHz, this might result in ugly
>decimal values. It seems common to use rounding to two digits after the
>decimal point.