### PR TITLE
Include refresh rate when determining maximum resolution

### DIFF
--- a/frontend/django_tests/test_models.py
+++ b/frontend/django_tests/test_models.py
@@ -74,6 +74,30 @@ class EDIDTestCase(EDIDTestMixin, TestCase):
             ]
         )
 
+    def test_get_maximum_resolution(self):
+        max_res = EDID(est_timings_640_480_60=True,
+                       est_timings_800_600_56=True).get_maximum_resolution()
+
+        self.assertEqual(max_res['horizontal_active'], 800)
+        self.assertEqual(max_res['vertical_active'], 600)
+        self.assertEqual(max_res['refresh_rate'], 56)
+
+        max_res = EDID(est_timings_800_600_56=True,
+                       est_timings_800_600_72=True,
+                       est_timings_800_600_75=True).get_maximum_resolution()
+
+        self.assertEqual(max_res['horizontal_active'], 800)
+        self.assertEqual(max_res['vertical_active'], 600)
+        self.assertEqual(max_res['refresh_rate'], 75)
+
+        max_res = EDID(est_timings_640_480_72=True,
+                       est_timings_640_480_75=True,
+                       est_timings_800_600_60=True).get_maximum_resolution()
+
+        self.assertEqual(max_res['horizontal_active'], 800)
+        self.assertEqual(max_res['vertical_active'], 600)
+        self.assertEqual(max_res['refresh_rate'], 60)
+
 
 class EDIDParsingTestCase(TestCase):
     def setUp(self):

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -611,7 +611,11 @@ class EDID(models.Model):
         maximum_resolution_pixels = maximum_resolution['horizontal_active'] \
             * maximum_resolution['vertical_active']
 
-        if (horizontal_active * vertical_active) > maximum_resolution_pixels:
+        resolution_pixels = horizontal_active * vertical_active
+
+        if resolution_pixels > maximum_resolution_pixels \
+            or (resolution_pixels == maximum_resolution_pixels
+                and refresh_rate > maximum_resolution['refresh_rate']):
             maximum_resolution = {
                 'horizontal_active': horizontal_active,
                 'vertical_active': vertical_active,


### PR DESCRIPTION
We currently report an incorrect refresh rate for the maximum resolution if there are further occurrences after the first one with higher refresh rates.