### PR TITLE
EDID 1.4 stuff

### DIFF
--- a/edid_parser/edid_parser.py
+++ b/edid_parser/edid_parser.py
@@ -156,8 +156,12 @@ class EDIDParser(object):
             raise EDIDParsingError("Week of manufacture (%d) is invalid." %
                                    (edid[8]))
 
-        self.data['Week_of_manufacture'] = edid[8]
-        self.data['Year_of_manufacture'] = edid[9] + 1990
+        year = edid[9] + 1990
+        if edid[8] == 0xff:
+            self.data['Model_Year'] = year
+        else:
+            self.data['Week_of_manufacture'] = edid[8]
+            self.data['Year_of_manufacture'] = year
 
         # EDID version and revision: edid[18:19]
         if (edid[10], edid[11]) in [(1, 0), (1, 1), (1, 2), (1, 3), (1, 4),

--- a/edid_parser/tests.py
+++ b/edid_parser/tests.py
@@ -96,13 +96,13 @@ class EDID13ValidTest(EDID13Test):
         self.assertEqual(self.parser.data['Extension_Flag'], 1)
 
     def test_header(self):
-        test_edid = [0x52, 0x62, 0x06, 0x02, 0x01, 0x01, 0x01, 0x01, 0xFF,
+        test_edid = [0x52, 0x62, 0x06, 0x02, 0x01, 0x01, 0x01, 0x01, 0x10,
                      0x13, 0x01, 0x03]
         self.parser.parse_header(test_edid)
 
         self.assertEqual(self.parser.data['ID_Manufacturer_Name'], 'TSB')
         self.assertEqual(self.parser.data['ID_Product_Code'], '0206')
-        self.assertEqual(self.parser.data['Week_of_manufacture'], 255)
+        self.assertEqual(self.parser.data['Week_of_manufacture'], 16)
         self.assertEqual(self.parser.data['Year_of_manufacture'], 2009)
         self.assertEqual(self.parser.data['ID_Serial_Number'], 16843009)
         self.assertEqual(self.parser.data['EDID_version'], 1)
@@ -539,6 +539,21 @@ class EDID14ValidTest(EDID14Test):
     """
     EDID 1.4 Parser tests with valid input.
     """
+
+    def test_header(self):
+        test_edid = [0x52, 0x62, 0x06, 0x02, 0x01, 0x01, 0x01, 0x01, 0xff,
+                     0x13, 0x01, 0x04]
+        self.parser.parse_header(test_edid)
+
+        self.assertNotIn('Week_of_manufacture', self.parser.data)
+        self.assertNotIn('Year_of_manufacture', self.parser.data)
+
+        self.assertEqual(self.parser.data['ID_Manufacturer_Name'], 'TSB')
+        self.assertEqual(self.parser.data['ID_Product_Code'], '0206')
+        self.assertEqual(self.parser.data['Model_Year'], 2009)
+        self.assertEqual(self.parser.data['ID_Serial_Number'], 16843009)
+        self.assertEqual(self.parser.data['EDID_version'], 1)
+        self.assertEqual(self.parser.data['EDID_revision'], 4)
 
     def test_basic_display(self):
         test_edid = [0xb5, 0x3c, 0x22, 0x78, 0x3a]

--- a/frontend/django_tests/test_views.py
+++ b/frontend/django_tests/test_views.py
@@ -271,6 +271,8 @@ class EDIDTestCase(EDIDTestMixin, TestCase):
         data['monitor_range_limits'] = False
 
         # Fields with null value will fail form validation
+        data['week_of_manufacture'] = ''
+        data['year_of_manufacture'] = ''
         data['bdp_signal_level_standard'] = 0
         data['mrl_secondary_gtf_start_freq'] = 0
         data['mrl_secondary_gtf_c'] = 0
@@ -353,6 +355,8 @@ class RevisionsTestCase(EDIDTestMixin, TestCase):
         data['monitor_range_limits'] = False
 
         # We need to fill these to validate the form
+        data['week_of_manufacture'] = ''
+        data['year_of_manufacture'] = ''
         data['bdp_signal_level_standard'] = 0
         data['mrl_secondary_gtf_start_freq'] = 0
         data['mrl_secondary_gtf_c'] = 0

--- a/frontend/forms.py
+++ b/frontend/forms.py
@@ -366,6 +366,7 @@ class EDIDUpdateForm(BaseForm):
 
         weeks_range = range(0, 55)
         weeks_range.append(255)
+        weeks_range.append(None)
 
         if week_of_manufacture not in weeks_range:
             raise forms.ValidationError('This field allowed range is'

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -79,10 +79,12 @@ class EDID(models.Model):
     # ID Serial Number, 32-bit
     manufacturer_serial_number = models.PositiveIntegerField(blank=True,
                                                              null=True)
-    # Week of manufacture, 1-54, 0==Unknown, 255==the year model
-    week_of_manufacture = models.PositiveSmallIntegerField()
+    # Week of manufacture, 1-54, 0==Unknown
+    week_of_manufacture = models.PositiveSmallIntegerField(blank=True, null=True)
     # Year of manufacture, 1990-2245
-    year_of_manufacture = models.PositiveSmallIntegerField()
+    year_of_manufacture = models.PositiveSmallIntegerField(blank=True, null=True)
+    # Model year, 1990-2245
+    model_year = models.PositiveSmallIntegerField(blank=True, null=True)
 
     # EDID version and revision
     VERSION_1_0 = 0
@@ -350,8 +352,11 @@ class EDID(models.Model):
         self.manufacturer_product_code = edid['ID_Product_Code']
         self.manufacturer_serial_number = edid['ID_Serial_Number']
 
-        self.week_of_manufacture = edid['Week_of_manufacture']
-        self.year_of_manufacture = edid['Year_of_manufacture']
+        if 'Model_Year' in edid:
+            self.model_year = edid['Model_Year']
+        else:
+            self.week_of_manufacture = edid['Week_of_manufacture']
+            self.year_of_manufacture = edid['Year_of_manufacture']
 
         if edid['EDID_version'] == 1:
             if edid['EDID_revision'] == 0:

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -153,7 +153,7 @@ class EDID(models.Model):
                                             decimal_places=2, blank=True,
                                             null=True)
 
-    BDP_FEATURE_DISPLY_CHOICE = (
+    BDP_FEATURE_DISPLAY_TYPE_CHOICE = (
         (DisplayType.Monochrome, 'Monochrome or grayscale display'),
         (DisplayType.RGB, 'RGB color display'),
         (DisplayType.Non_RGB, 'Non-RGB multicolor display'),
@@ -165,7 +165,7 @@ class EDID(models.Model):
     bdp_feature_active_off = models.BooleanField(
         'active off/very low power mode')
     bdp_feature_display_type = models.PositiveSmallIntegerField(
-        'display color type', choices=BDP_FEATURE_DISPLY_CHOICE)
+        'display color type', choices=BDP_FEATURE_DISPLAY_TYPE_CHOICE)
     bdp_feature_standard_srgb = models.BooleanField('standard sRGB')
     bdp_feature_pref_timing_mode = models.BooleanField(
         'preferred timing mode')

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -8,6 +8,7 @@
 from __future__ import division
 
 import re
+from decimal import Decimal
 
 from django.conf import settings
 from django.db import models
@@ -15,7 +16,9 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import reverse
 
 from edid_parser.edid_parser import (DisplayType, DisplayStereoMode,
-                                     TimingSyncScheme, CVTSupportDefinitionPreferredAspectRatio)
+                                     TimingSyncScheme,
+                                     CVTSupportDefinitionPreferredAspectRatio,
+                                     ColorBitDepth, DigitalVideoInterface)
 
 
 class Manufacturer(models.Model):
@@ -143,12 +146,54 @@ class EDID(models.Model):
         'serration on the vertical sync')
 
     # Digital Input
+    BDP_COLOR_BIT_DEPTH_CHOICE = (
+        (ColorBitDepth.Undefined, 'Undefined'),
+        (ColorBitDepth.Depth_6_bit, '6 bit'),
+        (ColorBitDepth.Depth_8_bit, '8 bit'),
+        (ColorBitDepth.Depth_10_bit, '10 bit'),
+        (ColorBitDepth.Depth_12_bit, '12 bit'),
+        (ColorBitDepth.Depth_14_bit, '14 bit'),
+        (ColorBitDepth.Depth_16_bit, '16 bit'),
+    )
+    bdp_color_bit_depth = models.PositiveSmallIntegerField(
+        'color bit depth', choices=BDP_COLOR_BIT_DEPTH_CHOICE, blank=True,
+        null=True)
+
+    BDP_DIGITAL_VIDEO_INTERFACE_CHOICE = (
+        (DigitalVideoInterface.Undefined, 'Undefined'),
+        (DigitalVideoInterface.DVI, 'DVI'),
+        (DigitalVideoInterface.HDMI_A, 'HDMI-A'),
+        (DigitalVideoInterface.HDMI_B, 'HDMI-B'),
+        (DigitalVideoInterface.MDDI, 'MDDI'),
+        (DigitalVideoInterface.DisplayPort, 'DisplayPort'),
+    )
+    bdp_digital_video_interface = models.PositiveSmallIntegerField(
+        'digital video interface', choices=BDP_DIGITAL_VIDEO_INTERFACE_CHOICE,
+        blank=True, null=True)
+
     bdp_video_input_dfp_1 = models.NullBooleanField('digital flat panel 1.x')
 
+    BDP_ASPECT_RATIO_CHOICE = (
+        (Decimal('1.78'), '16:9'),
+        (Decimal('0.56'), '9:16'),
+        (Decimal('1.60'), '16:10'),
+        (Decimal('0.62'), '10:16'),
+        (Decimal('1.33'), '4:3'),
+        (Decimal('0.75'), '3:4'),
+        (Decimal('1.25'), '5:4'),
+        (Decimal('0.80'), '4:5'),
+    )
+    bdp_aspect_ratio = models.DecimalField('aspect ratio', max_digits=3,
+       decimal_places=2, blank=True, null=True, choices=BDP_ASPECT_RATIO_CHOICE)
+    bdp_horizontal_screen_size = models.PositiveSmallIntegerField(
+        'horizontal screen size', blank=True, null=True)
+    bdp_vertical_screen_size = models.PositiveSmallIntegerField(
+        'vertical screen size', blank=True, null=True)
+
     bdp_max_horizontal_image_size = models.PositiveSmallIntegerField(
-        'maximum horizontal image size')
+        'maximum horizontal image size', blank=True, null=True)
     bdp_max_vertical_image_size = models.PositiveSmallIntegerField(
-        'maximum vertical image size')
+        'maximum vertical image size', blank=True, null=True)
     bdp_display_gamma = models.DecimalField('display gamma', max_digits=3,
                                             decimal_places=2, blank=True,
                                             null=True)
@@ -165,11 +210,18 @@ class EDID(models.Model):
     bdp_feature_active_off = models.BooleanField(
         'active off/very low power mode')
     bdp_feature_display_type = models.PositiveSmallIntegerField(
-        'display color type', choices=BDP_FEATURE_DISPLAY_TYPE_CHOICE)
+        'display color type', choices=BDP_FEATURE_DISPLAY_TYPE_CHOICE,
+        blank=True, null=True)
     bdp_feature_standard_srgb = models.BooleanField('standard sRGB')
     bdp_feature_pref_timing_mode = models.BooleanField(
         'preferred timing mode')
-    bdp_feature_default_gtf = models.BooleanField('default GTF')
+    bdp_feature_default_gtf = models.NullBooleanField('default GTF')
+
+    bdp_feature_rgb444 = models.NullBooleanField('RGB 4:4:4 supported')
+    bdp_feature_ycrcb444 = models.NullBooleanField('YCrCb 4:4:4 supported')
+    bdp_feature_ycrcb422 = models.NullBooleanField('YCrCb 4:2:2 supported')
+    bdp_feature_continuous_frequency = models.NullBooleanField(
+        'continuous frequency')
 
     ### chr=Chromaticity
     chr_red_x = models.DecimalField(
@@ -359,21 +411,50 @@ class EDID(models.Model):
             self.bdp_vsync_serration = bdp['Vsync_serration']
         else:
             # Digital Input
-            self.bdp_video_input_dfp_1 = bdp['Video_Input_DFP_1']
+            if self.version == self.VERSION_1_4:
+                self.bdp_color_bit_depth = bdp['Color_Bit_Depth']
+                self.bdp_digital_video_interface = \
+                    bdp['Digital_Video_Interface']
+                self.bdp_feature_rgb444 = \
+                    bdp['Feature_Support']['Color_Encoding_RGB444_Supported']
+                self.bdp_feature_ycrcb444 = \
+                    bdp['Feature_Support']['Color_Encoding_YCrCb444_Supported']
+                self.bdp_feature_ycrcb422 = \
+                    bdp['Feature_Support']['Color_Encoding_YCrCb422_Supported']
+            else:
+                self.bdp_video_input_dfp_1 = bdp['Video_Input_DFP_1']
 
-        self.bdp_max_horizontal_image_size = bdp['Max_Horizontal_Image_Size']
-        self.bdp_max_vertical_image_size = bdp['Max_Vertical_Image_Size']
+        if self.version == self.VERSION_1_4:
+            if 'Aspect_Ratio' in bdp:
+                self.bdp_aspect_ratio = bdp['Aspect_Ratio']
+
+            if 'Horizontal_Screen_Size' in bdp:
+                self.bdp_horizontal_screen_size = \
+                    bdp['Horizontal_Screen_Size']
+                self.bdp_vertical_screen_size = bdp['Vertical_Screen_Size']
+
+            self.bdp_feature_continuous_frequency = \
+                bdp['Feature_Support']['Continuous_Frequency']
+        else:
+            self.bdp_max_horizontal_image_size = bdp[
+                'Max_Horizontal_Image_Size']
+            self.bdp_max_vertical_image_size = bdp['Max_Vertical_Image_Size']
+
+            self.bdp_feature_default_gtf = bdp['Feature_Support']['Default_GTF']
+
         self.bdp_display_gamma = bdp['Display_Gamma']
 
         self.bdp_feature_standby = bdp['Feature_Support']['Standby']
         self.bdp_feature_suspend = bdp['Feature_Support']['Suspend']
         self.bdp_feature_active_off = bdp['Feature_Support']['Active-off']
-        self.bdp_feature_display_type = bdp['Feature_Support']['Display_Type']
         self.bdp_feature_standard_srgb = \
             bdp['Feature_Support']['Standard-sRGB']
         self.bdp_feature_pref_timing_mode = \
             bdp['Feature_Support']['Preferred_Timing_Mode']
-        self.bdp_feature_default_gtf = bdp['Feature_Support']['Default_GTF']
+
+        if 'Display_Type' in bdp['Feature_Support']:
+            self.bdp_feature_display_type = \
+                bdp['Feature_Support']['Display_Type']
 
         ### Chromaticity
         self.chr_red_x = edid['Chromaticity']['Red_x']

--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -60,6 +60,23 @@
             <td>{{ edid.bdp_display_gamma|floatformat:2 }}</td>
           </tr>
       {% endif %}
+      {% if edid.version == edid.VERSION_1_4 %}
+          {% if edid.bdp_aspect_ratio %}
+          <tr>
+            <td>Aspect ratio</td>
+            <td>{{ edid.get_bdp_aspect_ratio_display }}</td>
+          </tr>
+          {% elif edid.bdp_horizontal_screen_size %}
+          <tr>
+            <td>Horizontal screen size</td>
+            <td>{{ edid.bdp_horizontal_screen_size }} cm</td>
+          </tr>
+          <tr>
+            <td>Vertical screen size</td>
+            <td>{{ edid.bdp_vertical_screen_size }} cm</td>
+          </tr>
+          {% endif %}
+      {% else %}
           <tr>
             <td>Maximum horizontal image size</td>
             <td>{{ edid.bdp_max_horizontal_image_size }} cm</td>
@@ -72,6 +89,7 @@
             <td>Signal level input</td>
             <td>{{ edid.get_bdp_video_input_display }}</td>
           </tr>
+      {% endif %}
       {% if edid.bdp_video_input == edid.bdp_video_input_analog %}
           <tr>
             <td>Blank-to-black setup</td>
@@ -97,17 +115,28 @@
             <td>Signal Level Standard</td>
             <td>{{ edid.get_bdp_signal_level_standard_display }}</td>
           </tr>
+      {% elif edid.version == edid.VERSION_1_4 %}
+          <tr>
+            <td>Color depth</td>
+            <td>{{ edid.get_bdp_color_bit_depth_display }}</td>
+          </tr>
+          <tr>
+            <td>Digital video interface</td>
+            <td>{{ edid.get_bdp_digital_video_interface_display }}</td>
+          </tr>
       {% else %}
           <tr>
             <td>VESA DFP 1.x</td>
             <td><i class="icon-{{ edid.bdp_video_input_dfp_1|yesno:"ok,remove" }}"></i></td>
           </tr>
       {% endif %}
+      {% if edid.version != edid.VERSION_1_4 or edid.bdp_video_input == edid.bdp_video_input_analog %}
           <tr>
             <td>Display Type</td>
             <td>{{ edid.get_bdp_feature_display_type_display }}</td>
           </tr>
         </tbody>
+      {% endif %}
       </table>
       <h4>Feature Support</h4>
       <table class="table table-striped table-bordered">
@@ -115,10 +144,6 @@
           <tr>
             <td>Active-off</td>
             <td><i class="icon-{{ edid.bdp_feature_active_off|yesno:"ok,remove" }}"></i></td>
-          </tr>
-          <tr>
-            <td>Default GTF</td>
-            <td><i class="icon-{{ edid.bdp_feature_default_gtf|yesno:"ok,remove" }}"></i></td>
           </tr>
           <tr>
             <td>Preferred Timing Mode</td>
@@ -136,6 +161,40 @@
             <td>Suspend</td>
             <td><i class="icon-{{ edid.bdp_feature_suspend|yesno:"ok,remove" }}"></i></td>
           </tr>
+        {% if edid.version == edid.VERSION_1_4 %}
+          <tr>
+            <td>Continuous Frequency Display</td>
+            <td><i class="icon-{{ edid.bdp_feature_continuous_frequency|yesno:"ok,remove" }}"></i></td>
+          </tr>
+            {% if edid.bdp_video_input == edid.bdp_video_input_digital %}
+          <tr>
+            <td>Color Encodings</td>
+            <td class="nested-table">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>RGB 4:4:4</th>
+                    <th>YCrCb 4:4:4</th>
+                    <th>YCrCb 4:2:2</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><i class="icon-{{ edid.bdp_feature_rgb444|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.bdp_feature_ycrcb444|yesno:"ok,remove" }}"></i></td>
+                    <td><i class="icon-{{ edid.bdp_feature_ycrcb422|yesno:"ok,remove" }}"></i></td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+            {% endif %}
+        {% else %}
+          <tr>
+            <td>Default GTF</td>
+            <td><i class="icon-{{ edid.bdp_feature_default_gtf|yesno:"ok,remove" }}"></i></td>
+          </tr>
+        {% endif %}
         </tbody>
       </table>
     </section>

--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -7,6 +7,7 @@
 <div class="row">
   <div class="span3 sidenav">
     <ul class="nav nav-list sidenav" data-spy="affix">
+      <li><a href="#general_information"><i class="icon-chevron-right"></i> General Information</a> </li>
       <li><a href="#basic_display_parameters"><i class="icon-chevron-right"></i> Basic Display Parameters</a></li>
       <li><a href="#chromaticity"><i class="icon-chevron-right"></i> Chromaticity</a></li>
       <li><a href="#established_timings"><i class="icon-chevron-right"></i> Established Timings</a></li>
@@ -49,6 +50,44 @@
       <a class="btn btn-primary" href="{% url 'edid-download' edid.pk %}">Download binary</a>
     </p>
   {% endif %}
+
+    <section id="general_information">
+      <h3>General Information</h3>
+      <table class="table table-striped table-bordered">
+        <tbody>
+        <tr>
+          <td>EDID version</td>
+          <td>{{ edid.get_version_display }}</td>
+        </tr>
+        <tr>
+          <td>Maximum resolution</td>
+          {% with timing=edid.get_maximum_resolution %}
+            <td>{{ timing.horizontal_active }}x{{ timing.vertical_active }}@{{ timing.refresh_rate }}Hz</td>
+          {% endwith %}
+        </tr>
+        <tr>
+          <td>Video input</td>
+          <td>{{ edid.get_bdp_video_input_display }}</td>
+        </tr>
+        {% if edid.model_year %}
+        <tr>
+          <td>Model year</td>
+          <td>{{ edid.model_year }}</td>
+        </tr>
+        {% else %}
+        <tr>
+          <td>Manufacturing</td>
+          <td>
+      {% if edid.week_of_manufacture and edid.week_of_manufacture != 255 %}
+            Week {{ edid.week_of_manufacture }} of
+      {% endif %}
+            {{ edid.year_of_manufacture }}
+          </td>
+        </tr>
+        {% endif %}
+        </tbody>
+      </table>
+    </section>
 
     <section id="basic_display_parameters">
       <h3>Basic Display Parameters</h3>

--- a/templates/frontend/edid_table.html
+++ b/templates/frontend/edid_table.html
@@ -8,7 +8,6 @@
     {% endif %}
       <td>Name</td>
       <td>Serial Number</td>
-      <td>Manufacturing</td>
       <td>Video Input</td>
       <td>Monitor Range Limits</td>
       <td>Standard Timings</td>
@@ -25,12 +24,6 @@
     {% endif %}
       <td>{{ edid.monitor_name }}</td>
       <td>{{ edid.manufacturer_serial_number }}</td>
-      <td>
-    {% if edid.week_of_manufacture and edid.week_of_manufacture != 255 %}
-        Week {{ edid.week_of_manufacture }} of
-    {% endif %}
-        {{ edid.year_of_manufacture }}
-      </td>
       <td>{{ edid.get_bdp_video_input_display }}</td>
       <td><i class="icon-{{ edid.monitor_range_limits|yesno:"ok,remove" }}"></i></td>
       <td>{{ edid.standardtiming__count }}</td>


### PR DESCRIPTION
This PR contains some fixes to correctly parse EDID 1.4 structures, mostly for the _Basic Display Parameters_ section. 

I've also removed the manufacturing date from all EDID lists as EDID 1.4 allows to specify a model year instead of it and I didn't see a beautiful way of integrating it into the tables without cluttering them too much. Instead, I've added a _General Information_ table to the EDID detail page which contains the EDID version, the maximum resolution, the video input type and either the model year or the date of manufacturing.

This is what it looks like now (I've marked all fields that were added in EDID 1.4):
![screenshot from 2018-12-20 11-56-23](https://user-images.githubusercontent.com/1225211/50281077-a7c24e00-044e-11e9-8b8a-dea3bc971c65.png)

### Note
I am not really happy with the fix in https://github.com/timvideos/edid.tv/commit/30e5db2ec899289f939be7d6b5d2ca471e4d1545. The issue here is that `EDIDParsingTestCase` runs the EDID parser with EDID version 1.3 and then `test_version_revision_valid()` tries to populate the EDID model from the parsed data as if it was an EDID 1.4. https://github.com/timvideos/edid.tv/commit/a0660e370f5f802d3f60897c54423773fb1db953 has introduced branches depending on the EDID version in `_populate_from_edid_parser()` and expects that EDID 1.4-specific values like `Color_Bit_Depth` would be set which they are not because we previously parsed the EDID with version 1.3. 

The root cause here is probably that I am rather unhappy with the way the parser was implemented.  While this would introduce tighter coupling, I believe it wouldn't hurt to have the parser directly populate the model. This would save us a bunch of code and having declared properties feels cleaner than stuffing everything into a dict first. Then again, my experience with Python is rather limited and what I am saying might be completely stupid. Also, this would mean a major refactor of the parser.

### Note 2
In https://github.com/timvideos/edid.tv/pull/20, I've previously introduced a `__future__` import to `models.py` to get Python 3 division behavior as this was the only place where division is used in that file anyway. Here in this PR, I've opted to rely on Python 2 division behavior at one place as the same file already uses that. This makes the code somewhat inconsistent. The code base really should be upgraded to Python 3.

### Note 3
I never really tried clicking the "Update" button on EDID detail page before (I kinda thought it would be just the same as in the Django admin backend). I just realized that I would have needed to update the edit forms in https://github.com/timvideos/edid.tv/pull/18. This PR here is also missing the necessary changes. I suggest leaving it like this for now and fixing the forms in another PR.