### PR TITLE
Prefer serial number from detailed descriptor over ID serial number

### DIFF
--- a/frontend/django_tests/test_models.py
+++ b/frontend/django_tests/test_models.py
@@ -98,6 +98,18 @@ class EDIDTestCase(EDIDTestMixin, TestCase):
         self.assertEqual(max_res['vertical_active'], 600)
         self.assertEqual(max_res['refresh_rate'], 60)
 
+    def test_get_preferred_serial_number(self):
+        sn = EDID(monitor_serial_number="ABCXYZ").get_preferred_serial_number()
+        self.assertEqual(sn, "ABCXYZ")
+
+        sn = EDID(manufacturer_serial_number=123456)\
+            .get_preferred_serial_number()
+        self.assertEqual(sn, 123456)
+
+        sn = EDID(manufacturer_serial_number=123456,
+                  monitor_serial_number="ABCXYZ").get_preferred_serial_number()
+        self.assertEqual(sn, "ABCXYZ")
+
 
 class EDIDParsingTestCase(TestCase):
     EDID_BINARY = "\x00\xFF\xFF\xFF\xFF\xFF\xFF\x00\x52\x62\x06\x02" \

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -779,6 +779,10 @@ class EDID(models.Model):
 
         return maximum_resolution
 
+    def get_preferred_serial_number(self):
+        return self.monitor_serial_number if self.monitor_serial_number else \
+            self.manufacturer_serial_number
+
     def __unicode__(self):
         return "%s %s" % (self.manufacturer.name, self.monitor_name)
 

--- a/templates/frontend/edid_detail.html
+++ b/templates/frontend/edid_detail.html
@@ -29,9 +29,9 @@
   <div class="span9">
     <h2><a href="{% url 'manufacturer-detail' edid.manufacturer.pk %}">{{ edid.manufacturer.name }}</a></h2>
   {% if edid.monitor_name %}
-    <h3>{{ edid.monitor_name }} (S/N: {{ edid.manufacturer_serial_number }})</h3>
+    <h3>{{ edid.monitor_name }} (S/N: {{ edid.get_preferred_serial_number }})</h3>
   {% else %}
-    <h3>S/N: {{ edid.manufacturer_serial_number }}</h3>
+    <h3>S/N: {{ edid.get_preferred_serial_number }}</h3>
   {% endif %}
 
   {% if edid.is_revision %}

--- a/templates/frontend/edid_table.html
+++ b/templates/frontend/edid_table.html
@@ -23,7 +23,7 @@
       <td><a href="{% url 'manufacturer-detail' edid.manufacturer.pk %}">{{ edid.manufacturer.name }}</a></td>
     {% endif %}
       <td>{{ edid.monitor_name }}</td>
-      <td>{{ edid.manufacturer_serial_number }}</td>
+      <td>{{ edid.get_preferred_serial_number }}</td>
       <td>{{ edid.get_bdp_video_input_display }}</td>
       <td><i class="icon-{{ edid.monitor_range_limits|yesno:"ok,remove" }}"></i></td>
       <td>{{ edid.standardtiming__count }}</td>


### PR DESCRIPTION
The "ID serial number" usually isn't really useful as most vendors just fill it with some garbage value when there is also a (ASCII) serial number in one of the detailed descriptors, so prefer the latter if present. Note that many monitors only have a serial number detailed descriptor in their CTA-861 extension block which we currently don't parse, so for now we'll still display a garbage value for these monitors.

Btw, @mithro, saw you're at 35C3 too, wanna meet?